### PR TITLE
Fix regex crash on long matching sequences

### DIFF
--- a/src/circuit/CircuitAI.cpp
+++ b/src/circuit/CircuitAI.cpp
@@ -581,6 +581,7 @@ void CCircuitAI::CheatPreload()
 
 int CCircuitAI::Init(int skirmishAIId, const struct SSkirmishAICallback* sAICallback)
 {
+	LOG(version);
 	this->skirmishAIId = skirmishAIId;
 	// NOTE: Due to chewed API only SSkirmishAICallback have access to Engine
 	this->sAICallback = sAICallback;

--- a/src/circuit/CircuitAI.h
+++ b/src/circuit/CircuitAI.h
@@ -63,7 +63,7 @@ class CEnemyUnit;
 class CDebugDrawer;
 #endif
 
-constexpr char version[]{"1.0.1"};
+constexpr char version[]{"1.0.2"};
 
 class CException: public std::exception {
 public:

--- a/src/circuit/setup/SetupManager.cpp
+++ b/src/circuit/setup/SetupManager.cpp
@@ -75,29 +75,18 @@ void CSetupManager::DisabledUnits(const char* setupScript)
 	};
 
 	std::string modoptionsTag("[modoptions]");
-	auto itBegin = std::search(
+	std::string::const_iterator bodyBegin = std::search(
 			script.begin(), script.end(),
 			modoptionsTag.begin(), modoptionsTag.end(),
 			[](char ch1, char ch2) { return std::tolower(ch1) == ch2; }
 	);
-	if (itBegin != script.end()) {
-		std::advance(itBegin, modoptionsTag.length());
-		auto itEnd = itBegin;
-		int openBr = 0;
-		for (; itEnd != script.end(); ++itEnd) {
-			if (*itEnd == '{') {
-				++openBr;
-			} else if (*itEnd == '}') {
-				if (--openBr == 0) {
-					break;
-				}
-			}
-		}
+	if (bodyBegin != script.end()) {
+		std::advance(bodyBegin, modoptionsTag.length());
+		std::string::const_iterator bodyEnd = utils::EndInBraces(bodyBegin, script.end());
 
-		std::string modoptionsBody(itBegin, itEnd);
 		std::smatch disabledunits;
 		std::regex patternDisabled("disabledunits=(.*);", std::regex::ECMAScript | std::regex::icase);
-		if (std::regex_search(modoptionsBody, disabledunits, patternDisabled)) {
+		if (std::regex_search(bodyBegin, bodyEnd, disabledunits, patternDisabled)) {
 			// !setoptions disabledunits=armwar+armpw+raveparty+zenith+mahlazer
 			disableUnits(disabledunits[1]);
 		}

--- a/src/circuit/util/utils.h
+++ b/src/circuit/util/utils.h
@@ -189,6 +189,22 @@ static inline std::string MakeFileSystemCompatible(const std::string& str)
 	return cleaned;
 }
 
+static inline std::string::const_iterator EndInBraces(const std::string::const_iterator begin, const std::string::const_iterator end)
+{
+	std::string::const_iterator brEnd = begin;
+	int openBr = 0;
+	for (; brEnd != end; ++brEnd) {
+		if (*brEnd == '{') {
+			++openBr;
+		} else if (*brEnd == '}') {
+			if (--openBr == 0) {
+				break;
+			}
+		}
+	}
+	return brEnd;
+}
+
 ///*
 // *  Check if projected point onto line lies between 2 end-points
 // */


### PR DESCRIPTION
libstdc++ has recursive regex executor, and it fails on long matching sequences.